### PR TITLE
Correct name of method in readme

### DIFF
--- a/bird-or-bicycle/README.md
+++ b/bird-or-bicycle/README.md
@@ -14,7 +14,7 @@ bird-or-bicycle-download
 ### Usage
 ```python
 import bird_or_bicycle 
-train_dataset_folder = bird_or_bicycle.download_dataset('train')
+train_dataset_folder = bird_or_bicycle.get_dataset('train')
 
 # Use a pytorch directory-based dataset loader
 import torchvision.datasets


### PR DESCRIPTION
There was a typo in the name of the method used in the readme file. Correcting it from 'download_dataset' to 'get_dataset'.