### PR TITLE
Update documented split sizes for compatibility with 0.0.4

### DIFF
--- a/bird-or-bicycle/README.md
+++ b/bird-or-bicycle/README.md
@@ -29,6 +29,6 @@ train_generator = train_datagen.flow_from_directory(train_dataset_folder)
 
 # Splits
 
-- clean train -> 1k
-- clean test -> 1k
-- extras -> 40k
+- clean train -> 125 images/class
+- clean test -> 125 images/class
+- extras -> 13750 images/class


### PR DESCRIPTION
Related question: the leaderboard says defenses will be evaluated on 1000 images. Is this based on an earlier version of the dataset, using the 1000 image test set, or is this a separate hold-out set?