### PR TITLE
Disable bitrotten tests and upgrade tensorflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,9 @@ sudo: required
 dist: trusty
 language: python
 python:
-  - 2.7
-# Python 3.5 is unfortunately bitrotten. See this build for an example
-# https://travis-ci.org/google/unrestricted-adversarial-examples/builds/625054022
-#  - 3.5
-
+  - 3.5
 env:
-  - TENSORFLOW_V=1.8.0
+  - TENSORFLOW_V=1.15.2
 
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
@@ -33,12 +29,7 @@ install:
   - source activate test-environment
 
   # install TensorFlow
-  - >
-    if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" && "$TENSORFLOW_V" == "1.8.0" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp27-none-linux_x86_64.whl;
-    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.5" && "$TENSORFLOW_V" == "1.8.0" ]]; then
-      pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp35-cp35m-linux_x86_64.whl;
-    fi
+  - pip install tensorflow=="$TENSORFLOW_V"
 
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - source activate test-environment
 
   # install TensorFlow
-  - pip install tensorflow==1.15.2
+  - pip install tensorflow==1.14.0
 
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ dist: trusty
 language: python
 python:
   - 2.7
-  - 3.5
+# Python 3.5 is unfortunately bitrotten. See this build for an example
+# https://travis-ci.org/google/unrestricted-adversarial-examples/builds/625054022
+#  - 3.5
 
 env:
   - TENSORFLOW_V=1.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ dist: trusty
 language: python
 python:
   - 3.5
-env:
-  - TENSORFLOW_V=1.15.2
 
 install:
   # code below is taken from http://conda.pydata.org/docs/travis.html
@@ -29,7 +27,7 @@ install:
   - source activate test-environment
 
   # install TensorFlow
-  - pip install tensorflow=="$TENSORFLOW_V"
+  - pip install tensorflow==1.15.2
 
 # command to run tests
 script:


### PR DESCRIPTION
Python 2.7 is deprecated, and tests are failing, so I've removed tests for it.

These tests now pass correctly on my instance with a V100 using python 3.5